### PR TITLE
Update go version and use same version in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: 'go.sum'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gennaro-tedesco/gh-i
 
-go 1.18
+go 1.23.3
 
 require (
 	github.com/cli/go-gh v1.2.1


### PR DESCRIPTION
I'm glad to hear that we can update the Go version.

https://github.com/gennaro-tedesco/gh-i/pull/17#issuecomment-2490839111