### PR TITLE
Fix exit code of version flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache-dependency-path: 'go.sum'
-      - run: go build -v -race ./...
+      - name: Build
+        run: |
+          mkdir -p dist
+          go build -v -o dist -race ./...
+      - name: Smoke test
+        run: |
+          ./dist/gh-i --version
+          ./dist/gh-i --help

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /gh-i
 /gh-i.exe
+dist

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,8 +21,8 @@ var rootCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		version, _ := cmd.Flags().GetBool("version")
 		if version {
-			fmt.Println(VERSION)
-			os.Exit(1)
+			fmt.Fprintln(cmd.OutOrStdout(), VERSION)
+			return
 		}
 		state, _ := cmd.Flags().GetString("state")
 		title, _ := cmd.Flags().GetString("title")

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,20 @@
+package cmd
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersionFlag(t *testing.T) {
+	got := new(bytes.Buffer)
+	rootCmd.SetOut(got)
+	rootCmd.SetErr(got)
+	rootCmd.SetArgs([]string{"--version"})
+	err := rootCmd.Execute()
+	if assert.NoError(t, err) {
+		assert.Regexp(t, regexp.MustCompile(`^\d+\.\d+\.\d+(-\w+)?\n`), got.String())
+	}
+}


### PR DESCRIPTION
Currently `gh-i --version` exits with non 0 value.
Is this intentional behavior?